### PR TITLE
bug fixes for downloading, listview and duplicate attachments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "com.mickstarify.zooforzotero"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        versionCode 3
+        versionName "1.1a"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "zotero_api_key", apikeyProperties['zotero_api_key'])
         buildConfigField("String", "zotero_api_secret", apikeyProperties['zotero_api_secret'])
@@ -73,5 +73,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'com.google.firebase:firebase-analytics:17.2.0'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    releaseImplementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
 }

--- a/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/Contract.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/Contract.kt
@@ -40,6 +40,7 @@ interface Contract {
         fun closeQuery()
         fun updateLibraryRefreshProgress(progress: Int, total: Int)
         fun isShowingContent(): Boolean
+        fun cancelAttachmentDownload()
     }
 
     interface Model {
@@ -54,6 +55,7 @@ interface Contract {
         fun getCollections(): List<Collection>
         fun getAttachments(itemKey: String): List<Item>
         fun openAttachment(item: Item)
+        fun cancelAttachmentDownload()
         fun getSubCollections(collectionName: String): List<Collection>
         fun filterCollections(query: String): List<Collection>
         fun filterItems(query: String): List<Item>

--- a/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivity.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivity.kt
@@ -11,10 +11,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.widget.ListView
-import android.widget.ProgressBar
-import android.widget.TextView
-import android.widget.Toast
+import android.widget.*
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -154,26 +151,26 @@ class LibraryActivity : AppCompatActivity(), Contract.View,
 
         val swipeRefreshLayout = findViewById<SwipeRefreshLayout>(R.id.library_swipe_refresh)
 
-//        listView.setOnScrollListener(object : AbsListView.OnScrollListener {
-//            override fun onScroll(
-//                view: AbsListView,
-//                firstVisibleItem: Int,
-//                visibleItemCount: Int,
-//                totalItemCount: Int
-//            ) {
-//                if (listView.getChildAt(0) != null) {
-//                    swipeRefreshLayout.setEnabled(
-//                        listView.getFirstVisiblePosition() == 0 && listView.getChildAt(
-//                            0
-//                        ).getTop() == 0
-//                    )
-//                }
-//            }
-//
-//            override fun onScrollStateChanged(p0: AbsListView?, p1: Int) {
-//            }
-//
-//        })
+        listView.setOnScrollListener(object : AbsListView.OnScrollListener {
+            override fun onScroll(
+                view: AbsListView,
+                firstVisibleItem: Int,
+                visibleItemCount: Int,
+                totalItemCount: Int
+            ) {
+                if (listView.getChildAt(0) != null) {
+                    swipeRefreshLayout.setEnabled(
+                        listView.getFirstVisiblePosition() == 0 && listView.getChildAt(
+                            0
+                        ).getTop() == 0
+                    )
+                }
+            }
+
+            override fun onScrollStateChanged(p0: AbsListView?, p1: Int) {
+            }
+
+        })
     }
 
     override fun onRefresh() {

--- a/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivity.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivity.kt
@@ -113,6 +113,7 @@ class LibraryActivity : AppCompatActivity(), Contract.View,
             setSearchableInfo(searchManager.getSearchableInfo(componentName))
             setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                 override fun onQueryTextSubmit(query: String): Boolean {
+                    setTitle("Search results for $query")
                     return false
                 }
 
@@ -150,6 +151,29 @@ class LibraryActivity : AppCompatActivity(), Contract.View,
                 presenter.selectItem(entry.getItem())
             }
         }
+
+        val swipeRefreshLayout = findViewById<SwipeRefreshLayout>(R.id.library_swipe_refresh)
+
+//        listView.setOnScrollListener(object : AbsListView.OnScrollListener {
+//            override fun onScroll(
+//                view: AbsListView,
+//                firstVisibleItem: Int,
+//                visibleItemCount: Int,
+//                totalItemCount: Int
+//            ) {
+//                if (listView.getChildAt(0) != null) {
+//                    swipeRefreshLayout.setEnabled(
+//                        listView.getFirstVisiblePosition() == 0 && listView.getChildAt(
+//                            0
+//                        ).getTop() == 0
+//                    )
+//                }
+//            }
+//
+//            override fun onScrollStateChanged(p0: AbsListView?, p1: Int) {
+//            }
+//
+//        })
     }
 
     override fun onRefresh() {
@@ -238,6 +262,9 @@ class LibraryActivity : AppCompatActivity(), Contract.View,
         if (progressDialog == null) {
             progressDialog = ProgressDialog(this)
             progressDialog?.setTitle("Downloading File")
+            progressDialog?.setButton("Cancel") { dialogInterface, i ->
+                presenter.cancelAttachmentDownload()
+            }
         }
         if (total == 0) {
             progressDialog?.isIndeterminate = true
@@ -247,7 +274,7 @@ class LibraryActivity : AppCompatActivity(), Contract.View,
             progressDialog?.progress = progress
             progressDialog?.max = total
             if (total == -1) {
-                progressDialog?.setMessage("${progress}KB")
+                progressDialog?.setMessage("We are connecting to the zotero servers and requesting the file.")
             } else {
                 progressDialog?.setMessage("${progress}KB of ${total}KB")
             }
@@ -257,6 +284,7 @@ class LibraryActivity : AppCompatActivity(), Contract.View,
 
     override fun hideAttachmentDownloadProgress() {
         progressDialog?.hide()
+        progressDialog = null
     }
 
     /* Is called by the fragment when an attachment is openned by the user. */

--- a/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivityPresenter.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivityPresenter.kt
@@ -8,6 +8,11 @@ import java.io.File
 import java.util.*
 
 class LibraryActivityPresenter(val view: Contract.View, context: Context) : Contract.Presenter {
+    override fun cancelAttachmentDownload() {
+        model.cancelAttachmentDownload()
+        view.hideAttachmentDownloadProgress()
+    }
+
     override fun isShowingContent(): Boolean {
         return model.isDisplayingItems
     }
@@ -34,7 +39,6 @@ class LibraryActivityPresenter(val view: Contract.View, context: Context) : Cont
         entries.addAll(items.sortedBy { it.getTitle().toLowerCase(Locale.getDefault()) }
             .map { ListEntry(it) })
 
-        view.setTitle("Search Results for ${query}")
         view.populateEntries(entries)
     }
 

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/Model/Collection.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/Model/Collection.kt
@@ -30,11 +30,8 @@ class Collection(
     }
 
     fun addSubCollection(collection: Collection) {
-
-        if (subCollections == null) {
-            subCollections = LinkedList<Collection>()
-        }
-        if (!this.subCollections.contains(collection)) {
+        // check so we don't add duplicate collections.
+        if (this.subCollections.filter { it.key == collection.key }.isEmpty()) {
             subCollections.add(collection)
         }
     }

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/ZoteroAPIDownloadAttachmentListener.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/ZoteroAPIDownloadAttachmentListener.kt
@@ -1,10 +1,12 @@
 package com.mickstarify.zooforzotero.ZoteroAPI
 
 import java.io.File
+import java.util.concurrent.Future
 
 interface ZoteroAPIDownloadAttachmentListener {
     fun onProgressUpdate(progress: Long, total: Long)
     fun onNetworkFailure()
     fun onComplete(attachment: File)
     fun onFailure()
+    fun receiveTask(task: Future<Unit>)
 }

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/ZoteroDB.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/ZoteroDB.kt
@@ -19,7 +19,7 @@ class ZoteroDB(val context: Context) {
     var collections: List<Collection>? = null
         set(value) {
             field = value
-            this.populateCollectionChilren()
+            this.populateCollectionChildren()
             this.createCollectionItemMap()
         }
     var items: List<Item>? = null
@@ -100,8 +100,6 @@ class ZoteroDB(val context: Context) {
                 InputStreamReader(context.openFileInput(COLLECTIONS_FILENAME))
             this.collections = gson.fromJson(collectionsJsonReader, typeToken)
             collectionsJsonReader.close()
-            this.createCollectionItemMap()
-            this.populateCollectionChilren()
         } catch (e: Exception) {
             Log.e("zotero", "error loading collections from storage, deleting file.")
             this.deleteLocalStorage()
@@ -178,13 +176,13 @@ class ZoteroDB(val context: Context) {
     }
 
     /*we will do O(n^2) because I'm not bothered to create a map for what i presume is a small list.*/
-    fun populateCollectionChilren() {
+    fun populateCollectionChildren() {
         if (collections == null) {
             throw Exception("called populate collections with no collections!")
         }
         for (collection in collections!!) {
             if (collection.hasParent()) {
-                collections!!.filter { it.key == collection.getParent() }.firstOrNull()
+                collections?.filter { it.key == collection.getParent() }?.firstOrNull()
                     ?.addSubCollection(collection)
             }
         }


### PR DESCRIPTION
Fixed a bug where the swiperefresh wouldn't let you scroll up
Fixed a bug where duplicate collections were being shown
Improvements to downloading attachments,
* We no longer allow the user to initiate several downloads of the same file
* Added a cancel button
No longer run crashlytics in debug mode
Fixed a bug with search
