### PR TITLE
linked attachments and other small improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "com.mickstarify.zooforzotero"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 33
-        versionName "2.4"
+        versionCode 34
+        versionName "2.4a"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "zotero_api_key", apikeyProperties['zotero_api_key'])
         buildConfigField("String", "zotero_api_secret", apikeyProperties['zotero_api_secret'])

--- a/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/ItemView/ItemAttachmentEntry.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/ItemView/ItemAttachmentEntry.kt
@@ -1,7 +1,10 @@
 package com.mickstarify.zooforzotero.LibraryActivity.ItemView
 
 
+import android.app.AlertDialog
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -33,24 +36,38 @@ class ItemAttachmentEntry : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val linkMode = attachment?.getItemData("linkMode")
-
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.fragment_item_attachment_entry, container, false)
+        val layout = view.findViewById<ConstraintLayout>(R.id.constraintLayout_attachments_entry)
+
         val filename = view.findViewById<TextView>(R.id.textView_filename)
         filename.text = attachment?.data?.get("filename") ?: "unknown"
         if (linkMode == "linked_file") { // this variant uses title as a filename.
             filename.text = "[Linked] ${attachment?.getItemData("title")}"
+        }else if (linkMode == "linked_url") {
+            filename.text = "[Linked Url] ${attachment?.getItemData("title")}"
+            layout.setOnClickListener {
+                val url = attachment?.getItemData("url")
+                AlertDialog.Builder(context)
+                    .setMessage("Would you like to open this URL: $url")
+                    .setPositiveButton("Yes", {dialog, which ->
+                        val intent = Intent(Intent.ACTION_VIEW)
+                        intent.setData(Uri.parse(url))
+                        startActivity(intent)
+                    })
+                    .setNegativeButton("No", {_,_ -> })
+                    .show()
+            }
         }
 
         val filetype = attachment?.data!!["contentType"] ?: ""
-        val layout = view.findViewById<ConstraintLayout>(R.id.constraintLayout_attachments_entry)
         val icon = view.findViewById<ImageView>(R.id.imageView_attachment_icon)
         if (attachment?.isDownloadable() == true) {
             if (filetype == "application/pdf") {
                 icon.setImageResource(R.drawable.treeitem_attachment_pdf_2x)
             } else if (filetype == "image/vnd.djvu") {
                 icon.setImageResource(R.drawable.djvu_icon)
-            } else if (attachment?.getFileExtension() == "epub"){
+            } else if (attachment?.getFileExtension() == "epub") {
                 icon.setImageResource(R.drawable.epub_icon)
             }
             layout.setOnClickListener {

--- a/app/src/main/java/com/mickstarify/zooforzotero/SyncSetup/SyncSetupModel.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/SyncSetup/SyncSetupModel.kt
@@ -56,8 +56,7 @@ class SyncSetupModel(val presenter: SyncSetupPresenter, val context: Context) :
                         keyInfo.key
                     )
                     openLibrary()
-                }
-                if (response.code() == 404) {
+                } else if (response.code() == 404) {
                     presenter.createNetworkError("Error your key was not found. Server Response was:\n" + response.raw())
                 } else {
                     presenter.createNetworkError("Unknown network error, got back server code ${response.code()}")

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/AttachmentStorageManager.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/AttachmentStorageManager.kt
@@ -101,9 +101,9 @@ class AttachmentStorageManager @Inject constructor(
             val rootDocFile = DocumentFile.fromTreeUri(context, Uri.parse(location))
             var directory = rootDocFile?.findFile(item.itemKey.toUpperCase(Locale.ROOT))
             if (directory == null || directory.isDirectory == false) {
-                directory = rootDocFile?.createDirectory(item.itemKey.toUpperCase(Locale.ROOT))
+                return false
             }
-            val file = directory?.findFile(filename)
+            val file = directory.findFile(filename)
             if (file == null) {
                 return false
             }
@@ -112,7 +112,7 @@ class AttachmentStorageManager @Inject constructor(
                 return false
             }
             val exists = file.exists()
-            if (file.exists() && checkMd5) {
+            if (exists && checkMd5) {
                 return calculateMd5(context.contentResolver.openInputStream(file.uri)!!) == item.data["md5"]
             } else {
                 return exists

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/Item.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/Item.kt
@@ -79,7 +79,7 @@ class Item : Parcelable {
         get() = itemInfo.itemKey
 
     val itemType: String
-        get() = getItemData("itemType") ?: "error"
+        get() = data["itemType"] ?: "error"
 
     @IgnoredOnParcel
     @Ignore
@@ -107,13 +107,13 @@ class Item : Parcelable {
 
     fun getTitle(): String {
         val title = when (itemType) {
-            "case" -> this.getItemData("caseName")
-            "statute" -> this.getItemData("nameOfAct")
+            "case" -> this.data["caseName"]
+            "statute" -> this.data["nameOfAct"]
             "note" -> {
-                var noteHtml = this.getItemData("note")
+                var noteHtml = this.data["note"]
                 stripHtml(noteHtml ?: "unknown")
             }
-            else -> this.getItemData("title")
+            else -> this.data["title"]
         }
 
         return (title ?: "unknown")

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/ZoteroDB/ZoteroDB.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/ZoteroDB/ZoteroDB.kt
@@ -120,11 +120,13 @@ class ZoteroDB constructor(
         val completable =
             Completable.fromMaybe(zoteroDatabase.getItemsForGroup(groupID).doOnSuccess(
                 Consumer {
+                    Log.d("zotero", "loaded items from DB, setting now.")
                     items = it
                 }
             )).andThen(
                 Completable.fromMaybe(
                     zoteroDatabase.getAttachmentsForGroup(groupID).doOnSuccess(Consumer {
+                        Log.d("zotero", "Loading attachmentInfo from Database")
                         attachmentInfo = HashMap<String, AttachmentInfo>()
                         for (attachment in it) {
                             attachmentInfo!![attachment.itemKey] = attachment


### PR DESCRIPTION
* #51 added the ability to open linked attachments that exist in the user's custom path.
So for example, if on zotero I have an attached file called "/home/michael/Alice.pdf"
the app will check my custom path for the following files "/home/michael/Alice.pdf", "michael/Alice.pdf" or "Alice.pdf" and open that.
* can also open linked Urls
* can open any attachment ( issue #79 )
made a few other minor changes as well.