### PR TITLE
fix attachments path

### DIFF
--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/AttachmentStorageManager.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/AttachmentStorageManager.kt
@@ -19,7 +19,7 @@ import java.security.MessageDigest
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
-
+import java.io.File
 
 const val STORAGE_ACCESS_REQUEST = 1  // The request code
 
@@ -403,7 +403,9 @@ class AttachmentStorageManager @Inject constructor(
         var itemPath = item.data["path"] ?: ""
         // do some transformations for windows style paths
         // e.g C:\\Users\\michael\\file.txt -> C:/Users/michael/file.txt
-        itemPath = itemPath.replace("\\", "/")
+        itemPath = itemPath.replace("\\", File.separator)
+        //we get rid of zotero reserved expression on storaged path "attachemnts:"
+        itemPath = itemPath.replace("attachments:", "")
         val directories = itemPath.split("/")
         if (storageMode == StorageMode.CUSTOM) {
             for (index in directories.indices) {


### PR DESCRIPTION
This fixes the wrong path when trying to open linked files. 
I think you could potentially avoid iterating over directories by explicitly checking if the file exists instead of iterating and comparing files in subdirectories.  