### PR TITLE
Fix WebDAV issues

### DIFF
--- a/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivityModel.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/LibraryActivityModel.kt
@@ -44,9 +44,45 @@ import java.io.FileNotFoundException
 import java.util.LinkedList
 import java.util.Stack
 import java.util.concurrent.TimeUnit
+import java.text.NumberFormat
+import java.util.Locale
+import kotlin.math.ln
+import kotlin.math.pow
 import com.mickstarify.zooforzotero.ZoteroStorage.Database.Collection as ZoteroCollection
 
 private const val TAG = "LibraryActivityModel"
+
+private fun formatTimestamp(timestamp: Long?): String {
+	if (timestamp == null || timestamp <= 0) return "Unknown"
+	return java.text.DateFormat.getDateTimeInstance().format(java.util.Date(timestamp))
+}
+
+private fun formatWindowsStyleSize(byteCount: Long): String
+{
+	if (byteCount < 0) return "Unknown"
+
+	val units = arrayOf("B", "KiB", "MiB", "GiB", "TiB", "PiB")
+	val formatter = NumberFormat.getNumberInstance(Locale.US)
+
+	// Bytes case (no decimal)
+	if (byteCount < 1024)
+	{
+		return "${formatter.format(byteCount)} B"
+	}
+
+	// Determine unit index
+	val unitIndex = (ln(byteCount.toDouble()) / ln(1024.0)).toInt().coerceAtMost(units.lastIndex)
+
+	val unitValue = 1024.0.pow(unitIndex.toDouble())
+	val value = byteCount / unitValue
+
+	// Windows typically uses 2 decimal places for KiB and above
+	val valueFormatted = String.format(Locale.US, "%.2f", value)
+
+	val bytesFormatted = formatter.format(byteCount)
+
+	return "$valueFormatted ${units[unitIndex]} ($bytesFormatted B)"
+}
 
 class LibraryActivityModel(private val presenter: Contract.Presenter, val context: Context) :
     Contract.Model, OnSyncChangeListener {
@@ -333,6 +369,8 @@ class LibraryActivityModel(private val presenter: Contract.Presenter, val contex
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(object : Observer<DownloadProgress> {
                 var receivedMetadata = false
+					 var downloadedMetadataHash = ""
+					 var downloadedMtime = 0L
 
                 override fun onComplete() {
                     isDownloading = false
@@ -350,6 +388,20 @@ class LibraryActivityModel(private val presenter: Contract.Presenter, val contex
                         attachmentStorageManager.deleteAttachment(item)
                         return
                     } else {
+								if (receivedMetadata && downloadedMetadataHash != "") {
+									val remoteSizeBytes = attachmentStorageManager.getFileSize(item).getOrDefault(-1L)
+									zoteroDB.updateAttachmentMetadata(
+										item.itemKey,
+										downloadedMetadataHash,
+										downloadedMtime,
+										if (preferences.isWebDAVEnabled()) {
+											AttachmentInfo.WEBDAV
+										} else {
+											AttachmentInfo.ZOTEROAPI
+										},
+										remoteSizeBytes
+									).subscribeOn(Schedulers.io()).subscribe()
+								}
                         openPDF(item)
                     }
                 }
@@ -363,16 +415,8 @@ class LibraryActivityModel(private val presenter: Contract.Presenter, val contex
                     presenter.updateAttachmentDownloadProgress(t.progress, t.total)
                     if (!receivedMetadata && t.metadataHash != "") {
                         receivedMetadata = true
-                        zoteroDB.updateAttachmentMetadata(
-                            item.itemKey,
-                            t.metadataHash,
-                            t.mtime,
-                            if (preferences.isWebDAVEnabled()) {
-                                AttachmentInfo.WEBDAV
-                            } else {
-                                AttachmentInfo.ZOTEROAPI
-                            }
-                        ).subscribeOn(Schedulers.io()).subscribe()
+								downloadedMetadataHash = t.metadataHash
+								downloadedMtime = t.mtime
                     }
                 }
 
@@ -690,47 +734,83 @@ class LibraryActivityModel(private val presenter: Contract.Presenter, val contex
             })
     }
 
-    fun askToUploadAttachments(changedAttachments: List<Pair<Item, Int>>) {
+	fun askToUploadAttachments(changedAttachments: List<Pair<Item, Int>>) {
         // for the sake of sanity I will only ask to upload 1 attachment.
         // this is because of limitations of only having 1 upload occur concurrently
         // and my unwillingness to implement a chaining mechanism for uploads for what i expect to
         // be a niche power user.
-        val attachment = changedAttachments.first().first
-        val version = changedAttachments.first().second
-        val fileSizeBytes = attachmentStorageManager.getFileSize(
-            attachmentStorageManager.getAttachmentUri(attachment)
-        )
+		val attachment = changedAttachments.first().first
+		val openedVersion = changedAttachments.first().second
 
-        if (fileSizeBytes == 0L) {
-            Log.e("zotero", "avoiding uploading a garbage PDF")
-            attachmentStorageManager.deleteAttachment(attachment)
-            removeFromRecentlyViewed(attachment)
-            return
-        }
+		val localSizeBytes = attachmentStorageManager.getFileSize(
+			attachmentStorageManager.getAttachmentUri(attachment)
+		)
 
-        val sizeKiloBytes = "${fileSizeBytes / 1000}KB"
+		if (localSizeBytes == 0L) {
+			Log.e("zotero", "avoiding uploading a garbage PDF")
+			attachmentStorageManager.deleteAttachment(attachment)
+			removeFromRecentlyViewed(attachment)
+			return
+		}
+		Log.d("zotero", "askToUploadAttachments: attachment.itemKey=${attachment.itemKey}")
+		Log.d("zotero", "askToUploadAttachments: attachmentInfo map size=${zoteroDB.attachmentInfo?.size ?: -1}")
+		Log.d("zotero", "askToUploadAttachments: map contains key=${zoteroDB.attachmentInfo?.containsKey(attachment.itemKey)}")
 
-        val message =
-            "${attachment.data["filename"]!!} ($sizeKiloBytes) is different to Zotero's version. Would you like to upload this PDF to replace the remote version?"
+		val attachmentInfo = zoteroDB.attachmentInfo?.get(attachment.itemKey)
 
-        presenter.createYesNoPrompt(
-            "Detected changes to attachment",
-            message,
-            "Upload",
-            "No",
-            {
-                if (version < attachment.getVersion()) {
-                    presenter.createYesNoPrompt("Outdated Version",
-                        "This local copy is older than the version on Zotero's server, are you sure you upload (this will irreversibly overwrite the server's copy)",
-                        "I am sure",
-                        "Cancel",
-                        { uploadAttachment(attachment) },
-                        { removeFromRecentlyViewed(attachment) })
-                }
-                uploadAttachment(attachment)
-            },
-            { removeFromRecentlyViewed(attachment) })
-    }
+		Log.d(
+			"zotero",
+			"askToUploadAttachments: metadata for ${attachment.itemKey} -> " +
+				(if (attachmentInfo == null) "null" else "mtime=${attachmentInfo.mtime}, size=${attachmentInfo.remoteSizeBytes}")
+		)
+		val remoteSizeBytes = attachmentInfo?.remoteSizeBytes ?: -1L
+		val localSizeText = formatWindowsStyleSize(localSizeBytes)
+		val remoteSizeText = formatWindowsStyleSize(remoteSizeBytes)
+
+		val localMtime = attachmentStorageManager.getMtime(attachment)
+		val remoteMtime = attachmentInfo?.mtime
+		val localMtimeText = formatTimestamp(localMtime)
+		val remoteMtimeText = formatTimestamp(remoteMtime)
+
+		val filename = attachment.data["filename"] ?: attachment.getTitle()
+		val serverIsNewer = openedVersion < attachment.getVersion()
+		val hasRemoteSize = remoteSizeBytes >= 0
+		val hasRemoteMtime = remoteMtime != null && remoteMtime > 0
+
+		val message = buildString {
+			appendLine("$filename has local changes.")
+			appendLine()
+			appendLine("Local file:")
+			appendLine("• Size: $localSizeText")
+			appendLine("• Modified: $localMtimeText")
+
+			if (hasRemoteSize || hasRemoteMtime) {
+				appendLine()
+				appendLine("Server copy:")
+				if (hasRemoteSize) {
+					appendLine("• Size: $remoteSizeText")
+				}
+				if (hasRemoteMtime) {
+					appendLine("• Modified: $remoteMtimeText")
+				}
+			}
+			if (serverIsNewer) {
+				appendLine()
+				appendLine("Warning: the server copy is newer than the version you originally opened. Uploading will overwrite the server copy!")
+			}
+			appendLine()
+			append("Upload this file to replace the remote version?")
+		}
+
+		presenter.createYesNoPrompt(
+			"Upload changed attachment",
+			message,
+			if (serverIsNewer) "Overwrite server copy" else "Upload",
+			"No",
+			{ uploadAttachment(attachment) },
+			{ removeFromRecentlyViewed(attachment) }
+		)
+	}
 
     override fun uploadAttachment(attachment: Item) {
         val md5Key: String
@@ -763,11 +843,13 @@ class LibraryActivityModel(private val presenter: Contract.Presenter, val contex
                         override fun onComplete() {
                             presenter.stopUploadingAttachmentProgress()
                             removeFromRecentlyViewed(attachment)
+                            val remoteSizeBytes = attachmentStorageManager.getFileSize(attachment).getOrDefault(-1L)
                             zoteroDB.updateAttachmentMetadata(
                                 attachment.itemKey,
                                 attachmentStorageManager.calculateMd5(attachment),
                                 attachmentStorageManager.getMtime(attachment),
-                                AttachmentInfo.WEBDAV
+                                AttachmentInfo.WEBDAV,
+										  remoteSizeBytes
                             ).subscribeOn(Schedulers.io()).subscribe()
                         }
 
@@ -794,11 +876,13 @@ class LibraryActivityModel(private val presenter: Contract.Presenter, val contex
                     override fun onComplete() {
                         presenter.stopUploadingAttachmentProgress()
                         removeFromRecentlyViewed(attachment)
+            				val remoteSizeBytes = attachmentStorageManager.getFileSize(attachment).getOrDefault(-1L)
                         zoteroDB.updateAttachmentMetadata(
                             attachment.itemKey,
                             attachmentStorageManager.calculateMd5(attachment),
                             attachmentStorageManager.getMtime(attachment),
-                            AttachmentInfo.ZOTEROAPI
+                            AttachmentInfo.ZOTEROAPI,
+									 remoteSizeBytes
                         ).subscribeOn(Schedulers.io()).subscribe()
                     }
 
@@ -809,11 +893,13 @@ class LibraryActivityModel(private val presenter: Contract.Presenter, val contex
                     override fun onError(e: Throwable) {
                         if (e is AlreadyUploadedException) {
                             removeFromRecentlyViewed(attachment)
+            					 val remoteSizeBytes = attachmentStorageManager.getFileSize(attachment).getOrDefault(-1L)
                             zoteroDB.updateAttachmentMetadata(
                                 attachment.itemKey,
                                 attachmentStorageManager.calculateMd5(attachment),
                                 attachmentStorageManager.getMtime(attachment),
-                                AttachmentInfo.WEBDAV
+                                AttachmentInfo.WEBDAV,
+									 	  remoteSizeBytes
                             ).subscribeOn(Schedulers.io()).subscribe()
                             presenter.makeToastAlert("Attachment already up to date.")
                         } else if (e is PreconditionFailedException) {

--- a/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/WebDAV/WebDAVSetup.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/LibraryActivity/WebDAV/WebDAVSetup.kt
@@ -49,6 +49,7 @@ class WebDAVSetup : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         preferenceManager = PreferenceManager(this)
+        Log.d("zotero", "onCreate: saved auth mode = ${preferenceManager.getWebDAVAuthMode()}")
 
         textInputLayout_connectTimeout = findViewById(R.id.textInputLayout_webdav_connect_timeout)
         textInputLayout_readTimeout = findViewById(R.id.textInputLayout_webdav_read_timeout)
@@ -70,36 +71,32 @@ class WebDAVSetup : AppCompatActivity() {
                 "DIGEST"
             )
         )
-        (textInputLayout_auth_mode.editText as AutoCompleteTextView).apply {
-            setAdapter(authModeAdapter)
+			(textInputLayout_auth_mode.editText as AutoCompleteTextView).apply {
+				setAdapter(authModeAdapter)
 
-            this.listSelection = when (preferenceManager.getWebDAVAuthMode()) {
-                WebdavAuthMode.AUTOMATIC -> 0
-                WebdavAuthMode.BASIC -> 1
-                WebdavAuthMode.DIGEST -> 2
-            }
+				val savedAuthMode = preferenceManager.getWebDAVAuthMode()
+				val savedIndex = when (savedAuthMode) {
+					WebdavAuthMode.AUTOMATIC -> 0
+					WebdavAuthMode.BASIC -> 1
+					WebdavAuthMode.DIGEST -> 2
+				}
 
-            onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-                override fun onItemSelected(
-                    parent: AdapterView<*>?,
-                    view: View?,
-                    position: Int,
-                    id: Long
-                ) {
-                    val authMode = when (position) {
-                        0 -> WebdavAuthMode.AUTOMATIC
-                        1 -> WebdavAuthMode.BASIC
-                        2 -> WebdavAuthMode.DIGEST
-                        else -> WebdavAuthMode.AUTOMATIC
-                    }
-                    Log.d("Webdav", "Setting auth mode to ${authMode}")
-                    preferenceManager.setWebDAVAuthMode(authMode)
-                }
+				Log.d("zotero", "Auth UI init: savedAuthMode=$savedAuthMode savedIndex=$savedIndex")
 
-                override fun onNothingSelected(p0: AdapterView<*>?) {
-                }
-            }
-        }
+				// Show the saved value in the text box itself
+				setText(authModeAdapter.getItem(savedIndex), false)
+
+				setOnItemClickListener { parent, view, position, id ->
+					val authMode = when (position) {
+						0 -> WebdavAuthMode.AUTOMATIC
+						1 -> WebdavAuthMode.BASIC
+						2 -> WebdavAuthMode.DIGEST
+						else -> WebdavAuthMode.AUTOMATIC
+					}
+					preferenceManager.setWebDAVAuthMode(authMode)
+					Log.d("zotero", "Auth mode saved: ${preferenceManager.getWebDAVAuthMode()}")
+				}
+			}
 
         loadConfig()
 
@@ -199,6 +196,13 @@ class WebDAVSetup : AppCompatActivity() {
         textInputLayout_writeTimeout.editText!!.setText(
             preferenceManager.getWebDAVWriteTimeout().toString()
         )
+        	val authText = when (preferenceManager.getWebDAVAuthMode()) {
+				WebdavAuthMode.AUTOMATIC -> "AUTOMATIC"
+				WebdavAuthMode.BASIC -> "BASIC"
+				WebdavAuthMode.DIGEST -> "DIGEST"
+			}
+		(textInputLayout_auth_mode.editText as AutoCompleteTextView).setText(authText, false)
+		Log.d("zotero", "loadConfig: auth field text set to '$authText'")
     }
 
     private fun toggleAdvancedConfig() {
@@ -242,35 +246,42 @@ class WebDAVSetup : AppCompatActivity() {
         return !findViewById<CheckBox>(R.id.checkBox_Verify_ssl).isChecked
     }
 
-    fun makeConnection(address: String, username: String, password: String) {
-        val webDav = Webdav(preferenceManager)
-        startProgressDialog()
-        Completable.fromAction {
-            var status = false // default to false incase we get an exception
-            var hadAuthenticationError = false
-            var errorMessage = "unset"
-            status = webDav.testConnection()
-            if (status == false) {
-                throw Exception("Unspecified error.")
-            }
-        }.subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(object : CompletableObserver {
-                override fun onSubscribe(d: Disposable) {
-                }
+fun makeConnection(address: String, username: String, password: String) {
+	Log.d(
+		"zotero",
+		"makeConnection called: address='$address', user='$username', savedAuthMode=${preferenceManager.getWebDAVAuthMode()}, verifySSL=${preferenceManager.getVerifySSLForWebDAV()}, addZotero=${preferenceManager.getWebDAVAddZoteroToUrl()}"
+	)
 
-                override fun onComplete() {
-                    setWebDAVAuthentication(address, username, password)
-                    hideProgressDialog()
-                }
+	val webDav = Webdav(preferenceManager)
+	startProgressDialog()
 
-                override fun onError(e: Throwable) {
-                    notifyFailed("Error setting up webdav, message: $e")
-                    hideProgressDialog()
-                }
+	Completable.fromAction {
+		Log.d("zotero", "testConnection starting on background thread")
+		val status = webDav.testConnection()
+		Log.d("zotero", "testConnection returned status=$status")
+		if (!status) {
+			throw Exception("Unspecified error.")
+		}
+	}.subscribeOn(Schedulers.io())
+		.observeOn(AndroidSchedulers.mainThread())
+		.subscribe(object : CompletableObserver {
+			override fun onSubscribe(d: Disposable) {
+				Log.d("zotero", "makeConnection onSubscribe")
+			}
 
-            })
-    }
+			override fun onComplete() {
+				Log.d("zotero", "makeConnection onComplete; saving final auth")
+				setWebDAVAuthentication(address, username, password)
+				hideProgressDialog()
+			}
+
+			override fun onError(e: Throwable) {
+				Log.e("zotero", "makeConnection onError: ${e.javaClass.name}: ${e.message}", e)
+				notifyFailed("Error setting up webdav, message: $e")
+				hideProgressDialog()
+			}
+		})
+	}
 
     var progressDialog: ProgressDialog? = null
     fun startProgressDialog() {

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/Webdav.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/Webdav.kt
@@ -24,6 +24,7 @@ import okio.sink
 import okio.source
 import java.io.File
 import java.io.InputStream
+import java.net.ProtocolException
 import java.security.SecureRandom
 import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
@@ -34,15 +35,26 @@ import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
 class Webdav(
-    preferenceManager: PreferenceManager
+    private val preferenceManager: PreferenceManager
 ) {
     private var sardine: OkHttpSardine
     var address: String
 
 
-    fun testConnection(): Boolean {
-        return sardine.exists(address)
-    }
+	fun testConnection(): Boolean {
+		Log.d("zotero", "testConnection: address='$address'")
+		Log.d("zotero", "testConnection: authMode=${preferenceManager.getWebDAVAuthMode()}")
+		Log.d("zotero", "testConnection: username=${preferenceManager.getWebDAVUsername()}")
+
+		return try {
+			val result = sardine.exists(address)
+			Log.d("zotero", "testConnection result=$result")
+			result
+		} catch (e: Throwable) {
+			Log.e("zotero", "testConnection failed: ${e.javaClass.name}: ${e.message}", e)
+			throw e
+		}
+	}
 
     fun downloadPropToString(webpath: String): String {
         val reader = sardine.get(webpath).source()
@@ -130,6 +142,23 @@ class Webdav(
         return observable
     }
 
+	// Workaround for "HTTP 204 had non-zero Content-Length"
+	private fun safeDelete(url: String) {
+			try {
+				sardine.delete(url)
+			} catch (e: ProtocolException) {
+				Log.w("zotero", "WebDAV 204 workaround triggered: ${e.message}")
+				if (e.message?.startsWith("HTTP 204 had non-zero Content-Length") == true) {
+					// verify result
+					if (!sardine.exists(url)) {
+						Log.w("zotero", "Delete verified after ProtocolException; continuing.")
+						return
+					}
+				}
+				throw e
+			}
+		}
+
     fun uploadAttachment(
         attachment: Item,
         attachmentStorageManager: AttachmentStorageManager
@@ -175,10 +204,10 @@ class Webdav(
             // mostly useless step, delete any old _NEW.zip files that shouldn't exist
             // but might incase of a failed update earlier.
             if (sardine.exists(newZipPath)) {
-                sardine.delete(newZipPath)
+                safeDelete(newZipPath)
             }
             if (sardine.exists(newPropPath)) {
-                sardine.delete(newPropPath)
+                safeDelete(newPropPath)
             }
 
             // upload files
@@ -192,8 +221,8 @@ class Webdav(
             val zipPath = address + "/${attachment.itemKey.uppercase()}.zip"
             val propPath = address + "/${attachment.itemKey.uppercase()}.prop"
 
-            sardine.delete(propPath)
-            sardine.delete(zipPath)
+            safeDelete(propPath)
+            safeDelete(zipPath)
 
             sardine.move(newPropPath, propPath)
             sardine.move(newZipPath, zipPath)
@@ -210,14 +239,12 @@ class Webdav(
         val password = preferenceManager.getWebDAVPassword()
         val verifySSL = preferenceManager.getVerifySSLForWebDAV()
 
-
         val clientBuilder = OkHttpClient.Builder()
             .protocols(listOf(Protocol.HTTP_1_1, Protocol.HTTP_2))
             .callTimeout(0, TimeUnit.SECONDS) // no call timeout.
             .connectTimeout(preferenceManager.getWebDAVConnectTimeout(), TimeUnit.MILLISECONDS)
             .readTimeout(preferenceManager.getWebDAVReadTimeout(), TimeUnit.MILLISECONDS)
             .writeTimeout(preferenceManager.getWebDAVWriteTimeout(), TimeUnit.MILLISECONDS);
-
 
         if (username != "" && password != "") {
             val credentials = Credentials(username, password)

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/Webdav.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/Webdav.kt
@@ -167,7 +167,7 @@ class Webdav(
         * 1. Compress attachment into a ZIP file (using internal cache dir)
         * 2. Create  F3FXJF_NEW.prop file.
         * 3. Upload to webdav server F3FXJF_NEW.zip and F3FXJF_NEW.prop
-        * 4. send a delete request and  rename request to server so we have
+        * 4. send a delete request and rename request to server so we have
         *  F3FXJF.zip + F3FXJF.prop resulting*/
 
         return Completable.fromAction {
@@ -214,6 +214,7 @@ class Webdav(
             sardine.put(newPropPath, propFile, "text/plain")
             sardine.put(newZipPath, zipFile, "application/zip")
 
+            // Delete temporary files from app storage
             zipFile.delete()
             propFile.delete()
 
@@ -221,9 +222,11 @@ class Webdav(
             val zipPath = address + "/${attachment.itemKey.uppercase()}.zip"
             val propPath = address + "/${attachment.itemKey.uppercase()}.prop"
 
+            // Delete old remote files
             safeDelete(propPath)
             safeDelete(zipPath)
 
+            // Overwrite remote files
             sardine.move(newPropPath, propPath)
             sardine.move(newZipPath, zipPath)
 

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/ZoteroAPI.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroAPI/ZoteroAPI.kt
@@ -37,8 +37,10 @@ import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.IOException
 import java.util.LinkedList
 import java.util.concurrent.TimeUnit
+import kotlin.math.min
 
 
 const val BASE_URL = "https://api.zotero.org"
@@ -158,9 +160,6 @@ class ZoteroAPI(
             //stops here.
         }
 
-
-        val outputFileStream = attachmentStorageManager.getItemOutputStream(item)
-
         val observable = Observable.create<DownloadProgress> { emitter ->
 
             val downloader = if (!useGroup) {
@@ -169,10 +168,6 @@ class ZoteroAPI(
                 service.getFileForGroup(groupID, item.itemKey)
             }
             downloader.subscribe(object : Observer<Response<ResponseBody>> {
-                override fun onComplete() {
-                    emitter.onComplete()
-                }
-
                 override fun onSubscribe(d: Disposable) {
                     // do nothing.
                 }
@@ -183,41 +178,51 @@ class ZoteroAPI(
                         return
                     }
 
-                    val inputStream = response.body()?.byteStream()
-                    val fileSize = response.body()?.contentLength() ?: 0
-                    if (response.code() == 200) {
-                        val buffer = ByteArray(64768)
-                        var read = inputStream?.read(buffer) ?: 0
-                        var progress: Long = 0
-                        val md5Hash = item.data["md5"] ?: ""
-                        val mtime = (item.data["mtime"] ?: "0").toLong()
-                        while (read > 0) {
-                            try {
-                                progress += read
-                                emitter.onNext(
-                                    DownloadProgress(
-                                        progress = progress,
-                                        total = fileSize,
-                                        metadataHash = md5Hash,
-                                        mtime = mtime
-                                    )
-                                )
-                                outputFileStream.write(buffer, 0, read)
-                                read = inputStream?.read(buffer) ?: 0
-                            } catch (e: java.io.InterruptedIOException) {
-                                outputFileStream.close()
-                                inputStream?.close()
-                                throw (e)
-                            }
-                            progress += read
-                        }
-                        emitter.onComplete()
-                    } else if (response.code() == 404) {
+						  if (response.code() == 404) {
                         throw ZoteroNotFoundException("Not found on server.")
-                    } else {
+                    } else if (response.code() != 200) {
                         Log.e("zotero", "network error. response: ${response.body()}")
                         throw RuntimeException("Invalid server response code ${response.code()}")
                     }
+
+                		// HTTP 200: Continue
+                		val body = response.body() ?: throw IOException("Empty response body")
+							val fileSize = body.contentLength()
+
+
+                    // use()'s here will automatically close inputStream and outputSteam after ending
+							body.byteStream().use { inputStream ->
+								attachmentStorageManager.getItemOutputStream(item).use { outputFileStream ->
+									val buffer = ByteArray(64768)
+		                     var read = inputStream.read(buffer)
+		                     var progress: Long = 0
+		                     val md5Hash = item.data["md5"] ?: ""
+		                     val mtime = (item.data["mtime"] ?: "0").toLong()
+		                     while (read != -1) {
+			                    if (emitter.isDisposed == true) {
+			                        Log.d("zotero", "download was cancelled in progress.")
+			                        return
+			                    }
+                             progress += read
+                             outputFileStream.write(buffer, 0, read)
+                             emitter.onNext(
+                                 DownloadProgress(
+                                     progress = min(progress, fileSize),
+                                     total = fileSize,
+                                     metadataHash = md5Hash,
+                                     mtime = mtime
+                                 )
+                             )
+                             read = inputStream.read(buffer)
+		                     }
+		                 		// Success: onComplete() will occur next
+
+                     	}
+							}
+                }
+
+                override fun onComplete() {
+                    emitter.onComplete()
                 }
 
                 override fun onError(e: Throwable) {

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/AttachmentInfo.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/AttachmentInfo.kt
@@ -34,7 +34,8 @@ class AttachmentInfo(
     @ColumnInfo(name = "group") val groupParent: Int = Collection.NO_GROUP_ID,
     @ColumnInfo(name = "md5Key") val md5Key: String = "",
     @ColumnInfo(name = "mtime") val mtime: Long,
-    @ColumnInfo(name = "downloadedFrom") val downloadedFrom: String = UNSET
+    @ColumnInfo(name = "downloadedFrom") val downloadedFrom: String = UNSET,
+	 @ColumnInfo(name = "remoteSizeBytes") val remoteSizeBytes: Long = -1L
 ) : Parcelable {
     companion object {
         const val UNSET = "UNSET"

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/Database.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/Database.kt
@@ -26,7 +26,7 @@ import javax.inject.Singleton
         ItemCollection::class,
         AttachmentInfo::class
     ),
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 abstract class ZoteroRoomDatabase : RoomDatabase() {
@@ -48,7 +48,8 @@ class ZoteroDatabase @Inject constructor(val context: Context) {
         .addMigrations(MIGRATION_2_3)
         .addMigrations(MIGRATION_3_4)
         .addMigrations(MIGRATION_4_5)
-        .addMigrations(MIGRATION_5_6).build()
+        .addMigrations(MIGRATION_5_6)
+        .addMigrations(MIGRATION_6_7).build()
 
     fun addGroup(group: GroupInfo): Completable {
         return db.groupInfoDao().insertGroupInfos(group)

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/Migration.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/Database/Migration.kt
@@ -50,26 +50,34 @@ val MIGRATION_5_6 = object: Migration(5,6){
         // Create new table with correct primary key structure
         database.execSQL("""
             CREATE TABLE IF NOT EXISTS `ItemCreator_new` (
-                `parent` TEXT NOT NULL, 
-                `firstName` TEXT NOT NULL, 
-                `lastName` TEXT NOT NULL, 
-                `creatorType` TEXT NOT NULL, 
-                `order` INTEGER NOT NULL, 
-                PRIMARY KEY(`parent`, `firstName`, `lastName`, `creatorType`), 
+                `parent` TEXT NOT NULL,
+                `firstName` TEXT NOT NULL,
+                `lastName` TEXT NOT NULL,
+                `creatorType` TEXT NOT NULL,
+                `order` INTEGER NOT NULL,
+                PRIMARY KEY(`parent`, `firstName`, `lastName`, `creatorType`),
                 FOREIGN KEY(`parent`) REFERENCES `ItemInfo`(`itemKey`) ON UPDATE NO ACTION ON DELETE CASCADE
             )
         """.trimIndent())
-        
+
         // Copy data from old table to new table
         database.execSQL("""
-            INSERT INTO ItemCreator_new (parent, firstName, lastName, creatorType, `order`) 
+            INSERT INTO ItemCreator_new (parent, firstName, lastName, creatorType, `order`)
             SELECT parent, firstName, lastName, creatorType, `order` FROM ItemCreator
         """.trimIndent())
-        
+
         // Drop old table
         database.execSQL("DROP TABLE ItemCreator")
-        
+
         // Rename new table
         database.execSQL("ALTER TABLE ItemCreator_new RENAME TO ItemCreator")
     }
+}
+
+val MIGRATION_6_7 = object : Migration(6, 7) {
+	override fun migrate(database: SupportSQLiteDatabase) {
+		database.execSQL(
+			"ALTER TABLE AttachmentInfo ADD COLUMN remoteSizeBytes INTEGER NOT NULL DEFAULT -1"
+		)
+	}
 }

--- a/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/ZoteroDB/ZoteroDB.kt
+++ b/app/src/main/java/com/mickstarify/zooforzotero/ZoteroStorage/ZoteroDB/ZoteroDB.kt
@@ -114,28 +114,30 @@ class ZoteroDB(
         ))
     }
 
-    fun loadItemsFromDatabase(): Completable {
-        /* Load the items from Database as well as all the attachments. */
-        val completable =
-            Completable.fromMaybe(zoteroDatabase.getItemsForGroup(groupID).doOnSuccess(
-                Consumer {
-                    Log.d("zotero", "loaded ${it.size} items from DB for groupID=$groupID, setting now.")
-                    items = it
-                }
-            )).andThen(
-                Completable.fromMaybe(
-                    zoteroDatabase.getAttachmentsForGroup(groupID).doOnSuccess(Consumer {
-                        Log.d("zotero", "Loading attachmentInfo from Database")
-                        attachmentInfo = HashMap<String, AttachmentInfo>()
-                        for (attachment in it) {
-                            attachmentInfo!![attachment.itemKey] = attachment
-                        }
-                    })
-                )
-            )
-        return completable
-    }
+	fun loadItemsFromDatabase(): Completable {
+      /* Load the items from Database as well as all the attachments. */
+		attachmentInfo = HashMap<String, AttachmentInfo>()
 
+		return Completable.fromMaybe(
+			zoteroDatabase.getItemsForGroup(groupID).doOnSuccess(
+				Consumer {
+					Log.d("zotero", "loaded ${it.size} items from DB for groupID=$groupID, setting now.")
+					items = it
+				}
+			)
+		).andThen(
+			Completable.fromMaybe(
+				zoteroDatabase.getAttachmentsForGroup(groupID).doOnSuccess(
+					Consumer { list ->
+						Log.d("zotero", "Loading attachmentInfo from Database: ${list.size} rows for groupID=$groupID")
+						for (attachment in list) {
+							attachmentInfo!![attachment.itemKey] = attachment
+						}
+					}
+				)
+			)
+		)
+	}
 
     fun loadTrashItemsFromDB(): Completable{
         zoteroDatabase.getItemsFromUserTrash()
@@ -422,7 +424,8 @@ class ZoteroDB(
         itemKey: String,
         md5Key: String,
         mtime: Long,
-        downloadedFrom: String = AttachmentInfo.UNSET
+        downloadedFrom: String = AttachmentInfo.UNSET,
+			remoteSizeBytes: Long? = -1L
     ): Completable {
         val mDownloadedFrom = if (downloadedFrom == AttachmentInfo.UNSET) {
             // check to see if webdav is on, which implies that i was downloaded from webdav.
@@ -434,8 +437,16 @@ class ZoteroDB(
         } else {
             downloadedFrom
         }
-        val attachmentInfo = AttachmentInfo(itemKey, groupID, md5Key, mtime, mDownloadedFrom)
-        Log.d("zotero", "adding metadata for ${itemKey}, $md5Key - ${mDownloadedFrom}")
+		val existingInfo = attachmentInfo?.get(itemKey)
+		val attachmentInfo = AttachmentInfo(
+			itemKey,
+			groupID,
+			md5Key,
+			mtime,
+			mDownloadedFrom,
+			remoteSizeBytes ?: existingInfo?.remoteSizeBytes ?: -1L
+		)
+		Log.d("zotero", "adding metadata for $itemKey, $md5Key - $mDownloadedFrom (size=$remoteSizeBytes)")
 
         this.attachmentInfo!![itemKey] = attachmentInfo
         return zoteroDatabase.writeAttachmentInfo(attachmentInfo)
@@ -488,7 +499,7 @@ class ZoteroDB(
         }
 
         val itemsWithTag = LinkedList<Item>()
-        
+
         for (item in this.items!!){
             if (item.tags.filter { it.tag == tagName }.any()){
                 itemsWithTag.add(item)

--- a/app/src/main/res/layout/content_web_davsetup.xml
+++ b/app/src/main/res/layout/content_web_davsetup.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#F9F9F9"
+    android:background="?android:colorBackground"
     android:orientation="vertical"
     tools:context=".LibraryActivity.WebDAV.WebDAVSetup"
     tools:showIn="@layout/activity_web_dav_setup">
@@ -28,7 +28,7 @@
                 android:layout_marginStart="12dp"
                 android:layout_marginTop="12dp"
                 android:layout_marginEnd="12dp"
-                app:cardBackgroundColor="@android:color/white"
+                app:cardBackgroundColor="?attr/colorSurface"
                 app:cardCornerRadius="8dp"
                 app:cardElevation="4dp"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
-<resources>
-    <string name="app_name">Zoo for Zotero</string>
+﻿<resources>
+    <string name="app_name">Zoo for Zotero (MA)</string>
     <string name="title_activity_sync_setup">Sync Setup</string>
     <string name="title_activity_zotero_api_setup">Zotero API</string>
     <string name="title_activity_library">Loading</string>


### PR DESCRIPTION
## Summary
- Workaround for WebDav HTTP 204 response issue where DELETE operation was successful but returns Content-Length > 0
   - Some WebDAV servers (including cPanel WebDAV) return malformed 204 responses on DELETE.
   - A safeDelete() wrapper verifies deletion with sardine.exists() and continues if the file was actually removed.
- Fixed WebDav authentication mode selection not being persistently stored and recalled
   - The selected mode (BASIC/DIGEST/AUTOMATIC) was not being persisted correctly when returning to the setup screen.
- Fixed WebDav Setup screen background color on Dark mode
   - MaterialCardView used a hard-coded white background, causing incorrect rendering in dark themes.
   - Replaced with theme surface color.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature  
- [ ] 🔧 Improvement
- [ ] 💔 Breaking change
- [ ] 🏗️ Build/dependency changes

## Testing
- [x] Builds successfully
- [x] Tested on device/emulator
- [x] No regressions

## Related Issues
Fixes/Closes #220 

---
*Third-party Zotero client - not affiliated with Zotero*